### PR TITLE
Allow configuring Sharpe10 service owner

### DIFF
--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -40,6 +40,8 @@ The top-level `bootstrap_server*.sh` wrappers install prerequisites, seed enviro
 
 `make seed ROLE=server2` writes `/etc/sharpe10/dev.env` by concatenating the base + role overrides with helpful comments. Run it on every host, and rerun after editing env files.
 
+> ℹ️ **Account ownership:** `envs/dev.env` defines `SHARPE10_OWNER`, the user/group that should own Sharpe10 data paths. Override it before seeding if your hosts use a different service account—the bootstrap scripts rely on it when creating directories and granting Docker access.
+
 ## Make targets you will use most
 | Target | Purpose |
 | --- | --- |
@@ -60,26 +62,28 @@ The top-level `bootstrap_server*.sh` wrappers install prerequisites, seed enviro
    ```bash
    make dev-env
    ```
-3. **Seed environment on the host** (choose the role you are configuring)
+3. **Create or select the runtime account**
+   Ensure the system user/group referenced by `SHARPE10_OWNER` exists. The default `jake_morrison:jake_morrison` matches lab hosts; override it in your env files before bootstrapping if you use a different service account.
+4. **Seed environment on the host** (choose the role you are configuring)
    ```bash
    sudo make seed ROLE=server2
    make env ROLE=server2
    ```
-4. **For Swarm hosts** (server2 locally, server3 joins via docker CLI)
+5. **For Swarm hosts** (server2 locally, server3 joins via docker CLI)
    ```bash
    sudo make swarm-init        # run once on server2
    docker swarm join --token <WORKER_TOKEN> <MANAGER_IP>:2377   # server3
    ```
-5. **Render configs before deploying**
+6. **Render configs before deploying**
    ```bash
    make render
    ```
-6. **Deploy stacks from server2** (manager)
+7. **Deploy stacks from server2** (manager)
    ```bash
    make deploy-monitor
    make deploy-kafka
    ```
-7. **Smoke-test**
+8. **Smoke-test**
    ```bash
    make smoke ROLE=server2 SMOKE_MODE=live
    ```

--- a/envs/dev.env
+++ b/envs/dev.env
@@ -1,6 +1,8 @@
 # ===== Meta =====
 ENV_NAME=dev
 REPO_ROOT=/opt/sharpe10/S10-INFRA
+# Default system account to own Sharpe10 artifacts unless overridden per-host.
+SHARPE10_OWNER=jake_morrison:jake_morrison
 
 # ===== Hosts =====
 SERVER1_HOST=server1

--- a/ops/install_docker.sh
+++ b/ops/install_docker.sh
@@ -78,8 +78,17 @@ fi
 
 systemctl enable docker --now
 
-# Add your user to the docker group (safe if already in group)
-usermod -aG docker jake_morrison || true
+# Add configured owner to the docker group when requested
+if [[ -n "${SHARPE10_OWNER:-}" ]]; then
+  docker_user="${SHARPE10_OWNER%%:*}"
+  if id -u "$docker_user" &>/dev/null; then
+    usermod -aG docker "$docker_user" || true
+  else
+    echo "[docker] user '${docker_user}' not found; skipping docker group membership" >&2
+  fi
+else
+  echo "[docker] SHARPE10_OWNER not set; skipping docker group membership" >&2
+fi
 
 # --- Hold packages to prevent drift ---
 if [[ "$APT_HOLD_DOCKER" == "1" ]]; then

--- a/ops/setup_dirs.sh
+++ b/ops/setup_dirs.sh
@@ -4,5 +4,27 @@ for root in /srv/clickhouse /srv/kafka /srv/monitoring; do
   mkdir -p "$root"/{data,logs,conf,backups}
 done
 mkdir -p /srv/clickhouse/shadow /srv/clickhouse/native_backups
-chown -R jake_morrison:jake_morrison /srv
+
+owner_spec="${SHARPE10_OWNER:-}"
+if [[ -z "$owner_spec" ]]; then
+  fallback_user="${SUDO_USER:-$(id -un)}"
+  fallback_group="$(id -gn "$fallback_user" 2>/dev/null || id -gn)"
+  owner_spec="${fallback_user}:${fallback_group}"
+fi
+
+owner_user="${owner_spec%%:*}"
+if [[ "$owner_spec" == *":"* ]]; then
+  owner_group="${owner_spec#*:}"
+else
+  owner_group="${owner_user}"
+fi
+
+if id -u "$owner_user" &>/dev/null; then
+  if ! getent group "$owner_group" &>/dev/null; then
+    owner_group="$(id -gn "$owner_user")"
+  fi
+  chown -R "${owner_user}:${owner_group}" /srv
+else
+  echo "[dirs] user '${owner_user}' not found; skipping chown" >&2
+fi
 echo "[dirs] created"


### PR DESCRIPTION
## Summary
- add a configurable `SHARPE10_OWNER` default to `envs/dev.env`
- update directory bootstrap to respect the configured owner or fall back to the invoking user
- add Docker group membership for the configured owner only when defined and document the workflow in onboarding

## Testing
- make lint

------
https://chatgpt.com/codex/tasks/task_e_68cd80c6de8c832595e4f20ff97143c4